### PR TITLE
Show some quirks of literal values

### DIFF
--- a/src/application/App.java
+++ b/src/application/App.java
@@ -2,6 +2,44 @@ package application;
 
 public class App {
 	public static void main(String[] args) {
+		//some quirks of literal values
+		
+		long lValue = 1234;
+		//by default, long values are ints
+		System.out.println(lValue);
+		
+		long lValue2 = 1234567891234L;
+		//have to append the L so that Java
+		//knows it's a long
+		
+		float fValue = 7.34F;
+		//have to append the F so that Java
+		//doesn't put it as a double
+		
+		byte bValue = 127;
+		//bytes are signed - can be +ive or
+		//-ive
+		
+		/* there are 255 numbers in byte, but it;s
+		 * signed.  Can do something like
+		 * byte byteValue = (byte)245 
+		 * and this will work, but only up to 255
+		 */
+		
+		byte byteValue = (byte)200;
+		System.out.println(byteValue);
+		//this gets interpreted as a signed value
+		
+		//to show the actual value, use the bitwise and operator
+		System.out.println(byteValue & 0xFF);
+		
+		int iValue = 1_000_000;
+		System.out.println(iValue);
+		//can use _ to make the numbers more readable
+		
+		//scientific notation
+		double dValue = 1.5E6;
+		System.out.println(dValue);
 		
 	}
 }


### PR DESCRIPTION
Show some quirks of literal values.  For example, can use scientific notation for things like a long.  Can 'cast' byte for a value greater than -128 or 127 (up to 255), and can use the bitwise and operator (& 0xFF) to display the actual number.  Can use underscores in a large number to make it more readable.